### PR TITLE
Phase 3: Switch build workflow to registry cache chain

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -196,11 +196,6 @@ jobs:
             push_flag=(--push)
           fi
 
-          no_cache_flag=()
-          if [ "$REBUILD_CACHE" = "true" ]; then
-            no_cache_flag=(--no-cache)
-          fi
-
           tag_args=()
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
@@ -217,8 +212,15 @@ jobs:
             --cache-from "type=registry,ref=${REGISTRY}/${IMAGE_NAME}:cache-base"
             --cache-from "type=registry,ref=${REGISTRY}/${IMAGE_NAME}:cache-python"
             --cache-from "type=registry,ref=${REGISTRY}/${IMAGE_NAME}:cache-node"
-            --cache-from "type=registry,ref=${REGISTRY}/${IMAGE_NAME}:cache-builder"
           )
+
+          if [ "$REBUILD_CACHE" = "true" ]; then
+            echo "♻️  Rebuilding builder cache: skipping cache-builder layer reuse"
+          else
+            cache_from_args+=(
+              --cache-from "type=registry,ref=${REGISTRY}/${IMAGE_NAME}:cache-builder"
+            )
+          fi
 
           cache_to_args=(
             --cache-to "type=registry,ref=${REGISTRY}/${IMAGE_NAME}:cache-builder,mode=max,compression=zstd"
@@ -237,7 +239,6 @@ jobs:
             "${push_flag[@]}"
           )
 
-          build_args+=("${no_cache_flag[@]}")
           build_args+=("${tag_args[@]}")
           build_args+=("${label_args[@]}")
           build_args+=("${cache_from_args[@]}")
@@ -250,6 +251,7 @@ jobs:
         if: always()
         env:
           REBUILD_DEPS_CACHE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.rebuild-deps-cache || 'false' }}
+          REBUILD_CACHE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.rebuild-cache || 'false' }}
         run: |
           echo "## 🎯 缓存命中情况" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -265,6 +267,11 @@ jobs:
           echo "- **CACHED 行数**: ${cached_layers}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **总阶段记录**: ${total_layers}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$REBUILD_CACHE" = "true" ]; then
+            echo "- 本次构建跳过 \`cache-builder\` 读取以强制重建 builder 层" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           if [ "$REBUILD_DEPS_CACHE" = "true" ]; then
             cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -16,7 +16,11 @@ on:
         required: false
         default: 'true'
       rebuild-cache:
-        description: 'Force rebuild all caches'
+        description: 'Force rebuild builder cache for this run'
+        required: false
+        default: 'false'
+      rebuild-deps-cache:
+        description: 'Rebuild dependencies cache (triggers prewarm workflow)'
         required: false
         default: 'false'
 
@@ -132,9 +136,27 @@ jobs:
           df -h /
           
           echo "✅ Disk space cleanup completed"
-      
+
+      - name: Check available disk space before build
+        run: |
+          set -euo pipefail
+          echo "📊 Disk usage overview:"
+          df -h /
+          df -h /home/runner/work
+
+          available_kb=$(df --output=avail -k /home/runner/work | tail -n1 | tr -d ' ')
+          min_required_kb=$((4 * 1024 * 1024))
+
+          if [ "$available_kb" -lt "$min_required_kb" ]; then
+            echo "::error::Available disk space is below 4GB (current: $((available_kb / 1024)) MB)."
+            exit 1
+          fi
+
+          echo "✅ Available disk space is sufficient"
+
       - name: Set up Docker Buildx
-          
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -154,80 +176,106 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
-      
-      - name: Cache Docker layers with Local Cache (2025 Best Practice)
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-main
-            ${{ runner.os }}-buildx-
 
-      - name: Build and push Docker image with 2025 Best Practice Caching
-        uses: docker/build-push-action@v6
+      - name: Build and push Docker image using registry cache chain
+        id: build-runtime
+        shell: bash
         env:
-          DOCKER_BUILD_RECORD_UPLOAD: false
-          DOCKER_BUILD_SUMMARY: false
-          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
-        with:
-          context: .
-          file: ./Dockerfile
-          target: runtime
-          platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' && (github.event.inputs.push != 'false') }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          
-          # Registry Cache Strategy (解决基础镜像重复下载问题)
-          cache-from: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-            type=local,src=/tmp/.buildx-cache
-          
-          cache-to: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max,compression=zstd
-            type=local,dest=/tmp/.buildx-cache-new,mode=max
-          
-          # Build optimization flags
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
-            CEREBRAS_API_KEY=placeholder_for_build
-            JWT_SECRET=placeholder_for_build
-            DATABASE_URL=file:./data/app.db
-          
-          # Performance optimizations
-          no-cache: ${{ github.event.inputs.rebuild-cache == 'true' }}
-          
-          # Enable BuildKit features for better caching
-          load: false
-      
-      # Critical 2025 Cache Management Step
-      - name: Move Docker cache (Fix for docker/build-push-action#252)
+          TAGS: ${{ steps.meta.outputs.tags }}
+          LABELS: ${{ steps.meta.outputs.labels }}
+          PUSH_ENABLED: ${{ github.event_name != 'pull_request' && (github.event.inputs.push != 'false') }}
+          REBUILD_CACHE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.rebuild-cache || 'false' }}
         run: |
-          echo "Moving Docker cache to handle directory properly..."
-          rm -rf /tmp/.buildx-cache || true
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true
-          echo "✅ Cache move completed successfully"
-      
-      - name: Extract cache information (2025 Best Practice)
-        if: github.event_name != 'pull_request'
+          set -euo pipefail
+
+          echo "$TAGS" > tags.txt
+          echo "$LABELS" > labels.txt
+
+          push_flag=(--load)
+          if [ "$PUSH_ENABLED" = "true" ]; then
+            push_flag=(--push)
+          fi
+
+          no_cache_flag=()
+          if [ "$REBUILD_CACHE" = "true" ]; then
+            no_cache_flag=(--no-cache)
+          fi
+
+          tag_args=()
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            tag_args+=(--tag "$tag")
+          done < tags.txt
+
+          label_args=()
+          while IFS= read -r label; do
+            [ -z "$label" ] && continue
+            label_args+=(--label "$label")
+          done < labels.txt
+
+          cache_from_args=(
+            --cache-from "type=registry,ref=${REGISTRY}/${IMAGE_NAME}:cache-base"
+            --cache-from "type=registry,ref=${REGISTRY}/${IMAGE_NAME}:cache-python"
+            --cache-from "type=registry,ref=${REGISTRY}/${IMAGE_NAME}:cache-node"
+            --cache-from "type=registry,ref=${REGISTRY}/${IMAGE_NAME}:cache-builder"
+          )
+
+          cache_to_args=(
+            --cache-to "type=registry,ref=${REGISTRY}/${IMAGE_NAME}:cache-builder,mode=max,compression=zstd"
+          )
+
+          build_args=(
+            --builder "${{ steps.setup-buildx.outputs.name }}"
+            --progress plain
+            --file ./Dockerfile
+            --target runtime
+            --platform linux/amd64
+            --build-arg BUILDKIT_INLINE_CACHE=1
+            --build-arg CEREBRAS_API_KEY=placeholder_for_build
+            --build-arg JWT_SECRET=placeholder_for_build
+            --build-arg DATABASE_URL=file:./data/app.db
+            "${push_flag[@]}"
+          )
+
+          build_args+=("${no_cache_flag[@]}")
+          build_args+=("${tag_args[@]}")
+          build_args+=("${label_args[@]}")
+          build_args+=("${cache_from_args[@]}")
+          build_args+=("${cache_to_args[@]}")
+          build_args+=(.)
+
+          docker buildx build "${build_args[@]}" | tee build.log
+
+      - name: Report cache hit statistics
+        if: always()
+        env:
+          REBUILD_DEPS_CACHE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.rebuild-deps-cache || 'false' }}
         run: |
-          echo "## 🚀 Cache Performance (2025 Best Practice)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          echo "### **Cache Strategy Applied**" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ **Local Cache (Primary)**: Fast local disk access" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ **GitHub Actions Cache**: Persistent cross-run storage" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ **Cache Move Pattern**: Fixed directory handling issue" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          echo "### **Performance Expectations**" >> $GITHUB_STEP_SUMMARY
-          echo "- 🎯 **Next build time**: 5-8 minutes for code changes" >> $GITHUB_STEP_SUMMARY
-          echo "- ⚡ **Cache restore**: < 10 seconds (local) vs 60+ seconds (remote)" >> $GITHUB_STEP_SUMMARY
-          echo "- 🔄 **Hit rate**: >90% for code-only changes" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          echo "### **What to Look For**" >> $GITHUB_STEP_SUMMARY
-          echo "- Look for **'CACHED'** messages instead of 'Downloading'" >> $GITHUB_STEP_SUMMARY
-          echo "- Python dependencies should show as cached on second build" >> $GITHUB_STEP_SUMMARY
-          echo "- BuildKit should show cache hits in logs" >> $GITHUB_STEP_SUMMARY
+          echo "## 🎯 缓存命中情况" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -f build.log ]; then
+            cached_layers=$(grep -c " CACHED " build.log || true)
+            total_layers=$(grep -c " =>" build.log || true)
+          else
+            cached_layers=0
+            total_layers=0
+          fi
+
+          echo "- **CACHED 行数**: ${cached_layers}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **总阶段记录**: ${total_layers}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$REBUILD_DEPS_CACHE" = "true" ]; then
+            cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+> ⚠️ 本次请求包含 `rebuild-deps-cache=true`，请在本次构建后手动触发 `prewarm-deps.yml` workflow 以刷新 base/python/node 缓存层。
+
+EOF
+          fi
+
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+### 📌 下一步建议
+- 关注 BuildKit 日志中是否出现 "CACHED" 标记
+- 若缓存命中偏低，可先手动触发依赖预热工作流
+EOF
+      

--- a/documents/future-roadmap/ci-docker-cache-roadmap.md
+++ b/documents/future-roadmap/ci-docker-cache-roadmap.md
@@ -92,7 +92,7 @@
   - 通过 `docker buildx build`（`--progress plain` + `tee build.log`）记录完整日志，Summary 输出 `CACHED` 命中行数。
   - 在构建前执行 `df -h` 与 4 GB 阈值校验，空间不足时立即失败。
   - `workflow_dispatch` 新增 `rebuild-deps-cache` 输入，用于提醒手动触发预热 workflow 刷新依赖层。
-  - `rebuild-cache` 描述更新为“仅重建 builder cache”，避免误删 base/python/node。
+  - `rebuild-cache` 描述更新为“仅重建 builder cache”，并在执行时跳过 `cache-builder` 的 `cache-from` 引用，确保 base/python/node 层仍能命中缓存。
 
 ### 4. 远程服务器缓存预热
 - **一次性执行**：

--- a/documents/project-board.md
+++ b/documents/project-board.md
@@ -1,7 +1,6 @@
 # 工作流与功能看板
 
 ## To-Do
-- [ ] Phase 3: 调整主 workflow 使用多级 cache-from
 - [ ] Phase 4: 完善部署文档与缓存管理指南
 
 ## In Progress
@@ -11,6 +10,12 @@
 - [ ] （留空，提交 PR 后填入）
 
 ## Done
+- [x] 2025-10-07 **Phase 3: 调整主 workflow 使用多级 cache-from**
+  - `.github/workflows/build-and-push.yml` 采用 GHCR `cache-base/cache-python/cache-node/cache-builder` 链
+  - 移除 `actions/cache` 及本地缓存目录迁移步骤，仅推送 `cache-builder`
+  - 增加 `df -h` + 4GB 阈值检查，构建日志 `CACHED` 统计写入 Summary
+  - workflow_dispatch 新增 `rebuild-deps-cache` 输入，用于提醒触发 `prewarm-deps.yml`
+  - Summary 输出命中行数与后续建议
 - [x] 2025-10-07 **Phase 2: 依赖缓存预热工作流**
   - 创建 `prewarm-deps.yml`（三层缓存：base/python/node）
   - 季度版本标签：2025Q4（固定策略）

--- a/documents/project-status.md
+++ b/documents/project-status.md
@@ -3,10 +3,16 @@
 > 最近更新：2025-10-07。更新本文件时同步调整此处日期。
 
 ## 当前核心目标
-- [ ] CI/Docker 缓存优化（详见 `documents/future-roadmap/ci-docker-cache-roadmap.md`）。负责人：Claude。进度：Phase 2 已完成 ✅
+- [ ] CI/Docker 缓存优化（详见 `documents/future-roadmap/ci-docker-cache-roadmap.md`）。负责人：Claude。进度：Phase 3 已完成 ✅
 - [x] 重构 Kokoro TTS 模块并落地自检 CLI（详见 `documents/future-roadmap/tts-refactor-roadmap.md`）。负责人：待指定。进度：全部 4 阶段已完成 ✅
 
 ## 最近里程碑
+- 2025-10-07 **Phase 3: 主构建工作流切换至多级缓存链**
+  - 更新 `.github/workflows/build-and-push.yml`，改用 registry `cache-base/cache-python/cache-node/cache-builder` 链
+  - 移除 `actions/cache` + 本地目录迁移逻辑，统一推送 `cache-builder`（zstd 压缩）
+  - 新增磁盘空间检查（`df -h` + 4GB 阈值）及 BuildKit 日志命中统计写入 Summary
+  - 添加 `rebuild-deps-cache` 输入项，提醒触发 `prewarm-deps.yml` 以刷新依赖层
+  - Summary 输出包含命中行数与后续建议
 - 2025-10-07 **Phase 2: 依赖缓存预热工作流完成**
   - 创建 `.github/workflows/prewarm-deps.yml`（280 行）
   - 实现三层缓存预热：base → python → node

--- a/documents/workflow-snapshots/ci-runtime-snapshot.md
+++ b/documents/workflow-snapshots/ci-runtime-snapshot.md
@@ -36,6 +36,35 @@
 
 > 更新步骤：构建结束后复制 run 链接与摘要信息，按上述要点填写，耗时控制在 1 分钟内。
 
+## Phase 3 主 workflow 缓存链切换（2025-10-07）
+
+### Workflow 更新点
+- `.github/workflows/build-and-push.yml` 使用多级 `cache-from`：`cache-base` → `cache-python` → `cache-node` → `cache-builder`
+- `cache-to` 仅推送 `cache-builder`（zstd 压缩，保留业务层缓存）
+- 移除本地 `/tmp/.buildx-cache` 及 `actions/cache`，改用 BuildKit 原生 registry 缓存
+- 增加 `df -h` 空间快照与 4GB 阈值校验，失败时直接终止构建
+- 构建日志通过 `tee build.log` 保存，Summary 汇总 `CACHED` 命中行数
+- 新增 `workflow_dispatch.inputs.rebuild-deps-cache`，用于提醒同步触发 `prewarm-deps.yml`
+
+### 最近运行（待填充）
+- **运行时间**：待记录（例如：2025-10-07 18:30 UTC 推送触发）
+- **Run 链接**：待记录（https://github.com/.../runs/...）
+- **耗时**：待记录（目标 5-8 分钟内）
+- **缓存命中统计**：
+  - build.log 中 `CACHED` 行数：待记录
+  - 总阶段记录行数：待记录
+- **磁盘空间**：
+  - 构建前：待记录（`df -h /home/runner/work`）
+  - 构建后（可选）：待记录
+- **是否触发依赖预热提醒**：待记录（如 workflow_dispatch 设置 `rebuild-deps-cache=true`）
+- **问题 & 备注**：待记录（例如：builder cache miss 原因）
+
+### 验证要点
+- Summary 中出现“CACHED 行数”与“下一步建议”段落
+- BuildKit 日志包含 `CACHED` 关键字（至少 base/python/node 任一命中）
+- 构建耗时落在路线图目标区间
+- 若空间不足（<4GB），workflow 应直接失败并提示错误
+
 ## Phase 2 预热工作流基线（2025-10-07）
 
 ### 工作流配置


### PR DESCRIPTION
## Goal
- Update the main build workflow to consume the prewarmed multi-layer caches and remove the brittle local Buildx cache handling.

## Core changes
- [x] Replace the docker/build-push-action invocation with an explicit Buildx script that uses the GHCR `cache-base/cache-python/cache-node/cache-builder` chain and uploads only the builder cache layer.
- [x] Drop `actions/cache` usage plus the `/tmp/.buildx-cache` move step, and gate the build on a `df -h` check that enforces a 4 GB free-space minimum.
- [x] Capture BuildKit logs via `tee build.log`, surface cache hit counts in the step summary, and add a `rebuild-deps-cache` input to remind operators to trigger the prewarm workflow when necessary.
- [x] Synchronize project status, board, workflow snapshot, and roadmap docs to record Phase 3 completion details.

## Key decisions
- Keep pushing only the builder cache layer from the main workflow to avoid churn on the heavy dependency layers that are maintained by the prewarm job.
- Store BuildKit output locally so the workflow can quantify cache hits in the summary without relying on external tooling.

## Verification
- `npm run lint` *(fails on pre-existing eslint warnings about `any` usage and an unused icon import; no new issues introduced by this change)*

## Next step
- Proceed to Phase 4 once this PR is approved and merged (documentation refresh for cache/deployment guidance).


------
https://chatgpt.com/codex/tasks/task_e_68e5b01ff9fc832681144c558251308c